### PR TITLE
fix(mcp-language-server): pin to specific commit instead of main branch

### DIFF
--- a/packages/mcp-language-server/default.nix
+++ b/packages/mcp-language-server/default.nix
@@ -11,8 +11,8 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "isaacphi";
     repo = "mcp-language-server";
-    rev = "main"; # pin a SHA for full reproducibility
-    sha256 = "sha256-WCQH/eNYA8bSJwn3OPlhpEMuFua3fC8QCBIg3H4Yokk=";
+    rev = "46e2950b7969334780675e7797e13f140d2d42ac"; # Pinned to specific commit from 2025-05-22
+    sha256 = "sha256-T0wuPSShJqVW+CcQHQuZnh3JOwqUxAKv1OCHwZMr7KM=";
   };
 
   vendorHash = "sha256-3NEG9o5AF2ZEFWkA9Gub8vn6DNptN6DwVcn/oR8ujW0=";


### PR DESCRIPTION
This change pins the mcp-language-server package to a specific commit instead of using the main branch. This makes the build more reproducible and fixes the hash mismatch error.

Changes:
- Pin to commit 46e2950b7969334780675e7797e13f140d2d42ac
- Update SHA256 hash to match the pinned commit

The package has been tested locally and builds successfully.