### PR TITLE
Add Neo4j MCP servers and clean up dart-sass versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ NOTE: Not every package is cached.
 
  - git-cliff
  - cargo-expand-nightly (a wrapper around `cargo-expand`)
+ - mcp-neo4j-cypher (Neo4j MCP server for natural language to Cypher queries)
+ - mcp-neo4j-memory (Neo4j MCP server for knowledge graph memory)
+ - mcp-neo4j-cloud-aura-api (Neo4j MCP server for Aura cloud service management)
 
 ## Templates
 

--- a/flake.nix
+++ b/flake.nix
@@ -40,12 +40,15 @@
       else {};
 
     # ---------------------------------------------------------------------
-    # Overlay: add our custom packages (cargo-expand-nightly, dart-sass)
+    # Overlay: add our custom packages
     customPackagesOverlay = final: prev: {
       inherit
         (self.packages.${prev.system})
         cargo-expand-nightly
         dart-sass
+        mcp-neo4j-cypher
+        mcp-neo4j-memory
+        mcp-neo4j-cloud-aura-api
         ;
     };
 

--- a/packages.nix
+++ b/packages.nix
@@ -5,6 +5,7 @@
   ...
 }: let
   st_0_8_14 = pkgs.callPackage ./packages/st {};
+  neo4j-mcp-packages = pkgs.callPackage ./packages/neo4j-mcp {};
 in
   rec {
     dart-sass = dart-sass-1_60_0;
@@ -32,6 +33,14 @@ in
     dart-sass-1_60_0 =
       pkgs.callPackage ./packages/dart-sass-snapshot {version = "1.60.0";};
     mcp-language-server = pkgs.callPackage ./packages/mcp-language-server {};
+
+    # Neo4j MCP servers
+    inherit
+      (neo4j-mcp-packages)
+      mcp-neo4j-cypher
+      mcp-neo4j-memory
+      mcp-neo4j-cloud-aura-api
+      ;
 
     strongdm-cli = pkgs.callPackage ./packages/sdm-cli {version = "33.57.0";};
     github-mcp-server = pkgs.callPackage ./packages/github-mcp-server {};

--- a/packages.nix
+++ b/packages.nix
@@ -16,20 +16,6 @@ in
       inherit encodec; # makes the local copy visible
       inherit (pkgs.python311Packages) buildPythonPackage;
     };
-    dart-sass-1_52_1 =
-      pkgs.callPackage ./packages/dart-sass {version = "1.52.1";};
-    dart-sass-1_52_2 =
-      pkgs.callPackage ./packages/dart-sass {version = "1.52.2";};
-    dart-sass-1_53_0 =
-      pkgs.callPackage ./packages/dart-sass {version = "1.53.0";};
-    dart-sass-1_54_4 =
-      pkgs.callPackage ./packages/dart-sass {version = "1.54.4";};
-    dart-sass-1_57_1 =
-      pkgs.callPackage ./packages/dart-sass {version = "1.57.1";};
-    dart-sass-1_58_0 =
-      pkgs.callPackage ./packages/dart-sass-snapshot {version = "1.58.0";};
-    dart-sass-1_59_3 =
-      pkgs.callPackage ./packages/dart-sass-snapshot {version = "1.59.3";};
     dart-sass-1_60_0 =
       pkgs.callPackage ./packages/dart-sass-snapshot {version = "1.60.0";};
     mcp-language-server = pkgs.callPackage ./packages/mcp-language-server {};

--- a/packages/dart-sass-snapshot/default.nix
+++ b/packages/dart-sass-snapshot/default.nix
@@ -30,7 +30,7 @@ in
       install -m755 -D src/dart $out/bin/src/dart
       install -m755 -D src/sass.snapshot $out/bin/src/sass.snapshot
     '';
-    fixupPhase = ''
+    fixupPhase = lib.optionalString (!stdenv.isDarwin) ''
       patchelf \
           --set-interpreter ${binutils.dynamicLinker} \
           $out/bin/src/dart

--- a/packages/neo4j-mcp/default.nix
+++ b/packages/neo4j-mcp/default.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python3,
+  python3Packages,
+}: let
+  # Define versions and tags for each server based on git tags
+  serverInfo = {
+    "mcp-neo4j-cypher" = {
+      version = "0.2.1";
+      tag = "mcp-neo4j-cypher-v0.2.1";
+      dependencies = [
+        "mcp[cli]>=1.6.0"
+        "neo4j>=5.26.0"
+        "pydantic>=2.10.1"
+      ];
+    };
+    "mcp-neo4j-memory" = {
+      version = "0.1.3";
+      tag = "mcp-neo4j-memory-v0.1.3";
+      dependencies = [
+        "mcp>=0.10.0"
+        "neo4j>=5.26.0"
+      ];
+    };
+    "mcp-neo4j-cloud-aura-api" = {
+      version = "0.2.2";
+      tag = "mcp-neo4j-aura-manager-v0.2.2";
+      dependencies = [
+        "mcp>=1.6.0"
+        "requests>=2.31.0"
+      ];
+      # The package name in pyproject.toml is different from the directory name
+      pname = "mcp-neo4j-aura-manager";
+    };
+  };
+
+  # Build function for each server
+  buildServer = name: {
+    inherit name;
+    value = python3Packages.buildPythonApplication {
+      inherit (serverInfo.${name}) version;
+      pname = serverInfo.${name}.pname or name;
+
+      src = fetchFromGitHub {
+        owner = "neo4j-contrib";
+        repo = "mcp-neo4j";
+        rev = serverInfo.${name}.tag;
+        sha256 = "sha256-homihdVoOj7dO6bn5DffozK47X8pHwzLPvnSnfbF2so=";
+      };
+
+      sourceRoot = "source/servers/${name}";
+
+      format = "pyproject";
+
+      propagatedBuildInputs = with python3Packages; [
+        # Common dependencies
+        pydantic
+
+        # Add specific dependencies based on the server
+        (
+          if name == "mcp-neo4j-cypher"
+          then [
+            # For mcp-neo4j-cypher
+            neo4j
+            mcp
+          ]
+          else if name == "mcp-neo4j-memory"
+          then [
+            # For mcp-neo4j-memory
+            neo4j
+            mcp
+          ]
+          else [
+            # For mcp-neo4j-cloud-aura-api
+            requests
+            mcp
+          ]
+        )
+      ];
+
+      nativeBuildInputs = with python3Packages; [
+        hatchling
+      ];
+
+      meta = with lib; {
+        description = "Neo4j MCP Server for ${name}";
+        homepage = "https://github.com/neo4j-contrib/mcp-neo4j";
+        license = licenses.mit;
+        platforms = platforms.all;
+      };
+    };
+  };
+
+  servers = builtins.attrNames serverInfo;
+in
+  builtins.listToAttrs (map buildServer servers)


### PR DESCRIPTION
This PR adds three Neo4j MCP servers for natural language interaction with Neo4j databases:

- mcp-neo4j-cypher: For natural language to Cypher queries
- mcp-neo4j-memory: For knowledge graph memory storage
- mcp-neo4j-cloud-aura-api: For Neo4j Aura cloud service management

Additionally, it removes older dart-sass versions and fixes the dart-sass package to work correctly on macOS by making the patchelf step conditional.