### PR TITLE
Add mcp-prompts package

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ NOTE: Not every package is cached.
  - mcp-neo4j-cypher (Neo4j MCP server for natural language to Cypher queries)
  - mcp-neo4j-memory (Neo4j MCP server for knowledge graph memory)
  - mcp-neo4j-cloud-aura-api (Neo4j MCP server for Aura cloud service management)
+ - mcp-prompts (MCP server for managing prompts and templates)
  - wait-for-pr-checks (Monitor GitHub PR checks with exponential backoff)
 
 ## Utility Scripts

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
         (self.packages.${prev.system})
         cargo-expand-nightly
         dart-sass
+        mcp-prompts
         mcp-neo4j-cypher
         mcp-neo4j-memory
         mcp-neo4j-cloud-aura-api

--- a/packages.nix
+++ b/packages.nix
@@ -34,6 +34,7 @@ in
     wait-for-pr-checks = pkgs.callPackage ./packages/wait-for-pr-checks {};
 
     github-mcp-server = pkgs.callPackage ./packages/github-mcp-server {};
+    mcp-prompts = pkgs.callPackage ./packages/mcp-prompts {};
   }
   // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
     City = pkgs.callPackage ./packages/city-theme {};

--- a/packages/mcp-prompts/default.nix
+++ b/packages/mcp-prompts/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+buildNpmPackage rec {
+  pname = "mcp-prompts";
+  version = "1.2.39";
+
+  src = fetchFromGitHub {
+    owner = "sparesparrow";
+    repo = "mcp-prompts";
+    rev = "v${version}";
+    sha256 = "1p97pq0an7wpn77mbcvsxq45qdlxcpvmba05d0w1flfic5amx5wq";
+  };
+
+  npmDepsHash = "sha256-/YAsE26OV2dBDqSVEdVIB7guNRCmHlQtFTcZwGprqd4=";
+
+  meta = with lib; {
+    description = "An MCP server for managing prompts and prompt templates";
+    homepage = "https://github.com/sparesparrow/mcp-prompts";
+    license = licenses.mit;
+    mainProgram = "mcp-prompts";
+  };
+}


### PR DESCRIPTION
## Summary
- add mcp-prompts as an npm package
- expose mcp-prompts through the overlay
- document new package in README
- format package with `nix fmt`

## Testing
- `nix fmt .`
- `nix build .#mcp-prompts` *(fails: interrupted due to environment limits)*
- `nix flake show` *(fails: interrupted due to environment limits)*


------
https://chatgpt.com/codex/tasks/task_e_68425b2c7a888327ba317a22c27cd62c