### PR TITLE
fix(mcp-prompts): correct source hash mismatch

### DIFF
--- a/packages/mcp-prompts/default.nix
+++ b/packages/mcp-prompts/default.nix
@@ -13,7 +13,7 @@ buildNpmPackage rec {
     owner = "sparesparrow";
     repo = "mcp-prompts";
     rev = "v${version}";
-    sha256 = "sha256-CnF5dMfJaqDxUJgDK96PkAnAjIBtZ1R9YDUd+nc7GX8=";
+    sha256 = "sha256-mJdeVWHRURc4aAWoVfdlnTZcCO56s1XPsZcfqwC+J90=";
   };
 
   npmDepsHash = "sha256-/YAsE26OV2dBDqSVEdVIB7guNRCmHlQtFTcZwGprqd4=";


### PR DESCRIPTION
## Problem
The mcp-prompts package build was failing due to a hash mismatch between the expected and actual source content hash.

## Solution
Updated the sha256 hash in  from:
- 

To the correct hash:
- 

## Context
This fix addresses the build failure from PR #248 where the CI annotation provided the correct hash value. The hash mismatch was preventing the mcp-prompts package from building successfully.

## Testing
- [x] Hash updated to match CI annotation suggestion
- [ ] CI build should now pass for mcp-prompts package