### PR TITLE
Add basic tests for wait-for-pr-checks

### DIFF
--- a/packages/wait-for-pr-checks/default.nix
+++ b/packages/wait-for-pr-checks/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   src = ../../scripts/bin/wait-for-pr-checks;
 
   nativeBuildInputs = [makeWrapper];
-  nativeCheckInputs = [bats];
+  nativeCheckInputs = [bats jq];
   doCheck = true;
 
   dontUnpack = true;
@@ -27,6 +27,7 @@ stdenv.mkDerivation {
   '';
 
   checkPhase = ''
+    export WAIT_FOR_PR_CHECKS_BIN=$src
     bats ${./tests/wait-for-pr-checks.bats}
   '';
 

--- a/packages/wait-for-pr-checks/default.nix
+++ b/packages/wait-for-pr-checks/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation {
 
   src = ../../scripts/bin/wait-for-pr-checks;
 
-  nativeBuildInputs = [makeWrapper];
+  nativeBuildInputs = [makeWrapper bats];
+  doCheck = true;
 
   dontUnpack = true;
 
@@ -21,6 +22,10 @@ stdenv.mkDerivation {
     chmod +x $out/bin/wait-for-pr-checks
     wrapProgram $out/bin/wait-for-pr-checks \
       --prefix PATH : ${lib.makeBinPath [gh jq]}
+  '';
+
+  checkPhase = ''
+    bats ${./tests/wait-for-pr-checks.bats}
   '';
 
   meta = with lib; {

--- a/packages/wait-for-pr-checks/default.nix
+++ b/packages/wait-for-pr-checks/default.nix
@@ -4,6 +4,7 @@
   makeWrapper,
   gh,
   jq,
+  bats,
 }:
 stdenv.mkDerivation {
   pname = "wait-for-pr-checks";
@@ -11,7 +12,8 @@ stdenv.mkDerivation {
 
   src = ../../scripts/bin/wait-for-pr-checks;
 
-  nativeBuildInputs = [makeWrapper bats];
+  nativeBuildInputs = [makeWrapper];
+  nativeCheckInputs = [bats];
   doCheck = true;
 
   dontUnpack = true;

--- a/packages/wait-for-pr-checks/tests/wait-for-pr-checks.bats
+++ b/packages/wait-for-pr-checks/tests/wait-for-pr-checks.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+setup() {
+  TMPDIR="$BATS_TEST_DIRNAME/tmp"
+  mkdir -p "$TMPDIR"
+  PATH="$TMPDIR:$PATH"
+  export PATH
+}
+
+teardown() {
+  rm -rf "$TMPDIR"
+}
+
+write_gh_stub() {
+  local json="$1"
+  cat >"$TMPDIR/gh" <<EOF2
+#!/bin/sh
+echo '${json}'
+EOF2
+  chmod +x "$TMPDIR/gh"
+}
+
+script="$(realpath "$BATS_TEST_DIRNAME/../../../scripts/bin/wait-for-pr-checks")"
+
+@test "displays help message with --help flag" {
+  run "$script" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: wait-for-checks"* ]]
+}
+
+@test "exits with success when all checks pass" {
+  write_gh_stub '[{"name":"ci","state":"SUCCESS","link":"https://example.com"}]'
+  run "$script"
+  [ "$status" -eq 0 ]
+}
+
+@test "exits with failure when a check fails" {
+  write_gh_stub '[{"name":"ci","state":"FAILURE","link":"https://example.com"}]'
+  run "$script"
+  [ "$status" -eq 1 ]
+}
+
+@test "exits with code 2 when timeout is reached" {
+  write_gh_stub '[{"name":"ci","state":"PENDING","link":"https://example.com"}]'
+  run "$script" -t 1 -i 1
+  [ "$status" -eq 2 ]
+}

--- a/packages/wait-for-pr-checks/tests/wait-for-pr-checks.bats
+++ b/packages/wait-for-pr-checks/tests/wait-for-pr-checks.bats
@@ -20,7 +20,7 @@ EOF2
   chmod +x "$TMPDIR/gh"
 }
 
-script="$(realpath "$BATS_TEST_DIRNAME/../../../scripts/bin/wait-for-pr-checks")"
+script="${WAIT_FOR_PR_CHECKS_BIN:-$(realpath "$BATS_TEST_DIRNAME/../../../scripts/bin/wait-for-pr-checks")}"
 
 @test "displays help message with --help flag" {
   run "$script" --help

--- a/packages/wait-for-pr-checks/tests/wait-for-pr-checks.bats
+++ b/packages/wait-for-pr-checks/tests/wait-for-pr-checks.bats
@@ -3,8 +3,9 @@
 setup() {
   TMPDIR="$BATS_TEST_DIRNAME/tmp"
   mkdir -p "$TMPDIR"
+  ln -s "$(command -v jq)" "$TMPDIR/jq"
   PATH="$TMPDIR:$PATH"
-  export PATH
+  export PATH JQ_BIN="$TMPDIR/jq"
 }
 
 teardown() {

--- a/scripts/bin/wait-for-pr-checks
+++ b/scripts/bin/wait-for-pr-checks
@@ -12,8 +12,13 @@
 #   -h, --help               Show this help message
 #
 # Dependencies: gh (GitHub CLI), jq
+# Use GH_BIN and JQ_BIN env variables to override the commands
 
 set -e  # Exit immediately if a command exits with non-zero status
+
+# Allow overriding gh and jq for testing
+GH_BIN="${GH_BIN:-gh}"
+JQ_BIN="${JQ_BIN:-jq}"
 
 # Default configuration
 TIMEOUT=600      # 10 minutes total timeout
@@ -48,7 +53,7 @@ EOF
 
 # Function to check dependencies
 check_dependencies() {
-    for cmd in gh jq; do
+    for cmd in "$GH_BIN" "$JQ_BIN"; do
         if ! command -v "$cmd" >/dev/null 2>&1; then
             echo "${RED}Error: Required command '$cmd' not found${RESET}" >&2
             echo "Please install the missing dependencies and try again." >&2
@@ -169,24 +174,24 @@ while [ "$all_complete" = false ] && [ "$total_wait" -lt "$TIMEOUT" ]; do
     echo "${BOLD}Check attempt $attempt (Total wait: ${total_wait}s):${RESET}"
     
     # Get check status in JSON format for better parsing
-    checks=$(gh pr checks --json name,state,link 2>/dev/null)
-    if ! gh pr checks --json name,state,link >/dev/null 2>&1; then
+    checks=$("$GH_BIN" pr checks --json name,state,link 2>/dev/null)
+    if ! "$GH_BIN" pr checks --json name,state,link >/dev/null 2>&1; then
         echo "${RED}Error: Failed to get PR checks. Are you in a git repository with an open PR?${RESET}" >&2
         exit 1
     fi
     
     # Display current status in a neat table
     print_table_header
-    echo "$checks" | jq -r '.[] | [.name, .state] | @tsv' | while IFS="$(printf '\t')" read -r name state; do
+    echo "$checks" | "$JQ_BIN" -r '.[] | [.name, .state] | @tsv' | while IFS="$(printf '\t')" read -r name state; do
         print_table_row "$name" "$state"
     done
     print_table_footer
     
     # Count pending checks (including QUEUED status)
-    pending_count=$(echo "$checks" | jq -r '[.[] | select(.state == "PENDING" or .state == "IN_PROGRESS" or .state == "QUEUED")] | length')
+    pending_count=$(echo "$checks" | "$JQ_BIN" -r '[.[] | select(.state == "PENDING" or .state == "IN_PROGRESS" or .state == "QUEUED")] | length')
     
     # Count failed checks (excluding QUEUED status)
-    failed_count=$(echo "$checks" | jq -r '[.[] | select(.state != "SUCCESS" and .state != "PENDING" and .state != "IN_PROGRESS" and .state != "QUEUED")] | length')
+    failed_count=$(echo "$checks" | "$JQ_BIN" -r '[.[] | select(.state != "SUCCESS" and .state != "PENDING" and .state != "IN_PROGRESS" and .state != "QUEUED")] | length')
     
     echo ""
     echo "$pending_count checks still pending"
@@ -196,7 +201,7 @@ while [ "$all_complete" = false ] && [ "$total_wait" -lt "$TIMEOUT" ]; do
         echo "${RED}❌ Some checks failed! (Exiting early due to fail-fast mode)${RESET}"
         # Show detailed information for failed checks
         printf "\n%sFailed checks details:%s\n" "$YELLOW" "$RESET"
-        echo "$checks" | jq -r '.[] | select(.state != "SUCCESS" and .state != "PENDING" and .state != "IN_PROGRESS" and .state != "QUEUED") | "- \(.name)\n  URL: \(.link)\n"'
+        echo "$checks" | "$JQ_BIN" -r '.[] | select(.state != "SUCCESS" and .state != "PENDING" and .state != "IN_PROGRESS" and .state != "QUEUED") | "- \(.name)\n  URL: \(.link)\n"'
         exit 1
     fi
     
@@ -208,7 +213,7 @@ while [ "$all_complete" = false ] && [ "$total_wait" -lt "$TIMEOUT" ]; do
             echo "${RED}❌ Some checks failed!${RESET}"
             # Show detailed information for failed checks
             printf "\n%sFailed checks details:%s\n" "$YELLOW" "$RESET"
-            echo "$checks" | jq -r '.[] | select(.state != "SUCCESS" and .state != "PENDING" and .state != "IN_PROGRESS" and .state != "QUEUED") | "- \(.name)\n  URL: \(.link)\n"'
+            echo "$checks" | "$JQ_BIN" -r '.[] | select(.state != "SUCCESS" and .state != "PENDING" and .state != "IN_PROGRESS" and .state != "QUEUED") | "- \(.name)\n  URL: \(.link)\n"'
             exit 1
         else
             echo "${GREEN}✅ All checks passed successfully!${RESET}"


### PR DESCRIPTION
## Summary
- allow overriding gh and jq commands via GH_BIN and JQ_BIN
- add Bats tests for wait-for-pr-checks
- enable test running in package derivation

## Testing
- `nix run nixpkgs#bats -- packages/wait-for-pr-checks/tests/wait-for-pr-checks.bats`

------
https://chatgpt.com/codex/tasks/task_e_6843c4d2f4c88327868e5e7d4a6eb73a