### PR TITLE
Add mcp-inspector package

### DIFF
--- a/packages.nix
+++ b/packages.nix
@@ -34,6 +34,7 @@ in
     wait-for-pr-checks = pkgs.callPackage ./packages/wait-for-pr-checks {};
 
     github-mcp-server = pkgs.callPackage ./packages/github-mcp-server {};
+    mcp-inspector = pkgs.callPackage ./packages/mcp-inspector {};
     mcp-prompts = pkgs.callPackage ./packages/mcp-prompts {};
   }
   // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {

--- a/packages/mcp-inspector/default.nix
+++ b/packages/mcp-inspector/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs,
+  jq,
+  ...
+}:
+buildNpmPackage rec {
+  pname = "mcp-inspector";
+  version = "0.14.0";
+
+  src = fetchFromGitHub {
+    owner = "modelcontextprotocol";
+    repo = "inspector";
+    rev = version;
+    sha256 = "sha256-Yelijo9YIpZXotXhaxduNaP++8uKUaGnx59KsVeEpNc=";
+  };
+
+  postPatch = ''
+    ${jq}/bin/jq '.packages["node_modules/router/node_modules/path-to-regexp"] += {
+      resolved: "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      integrity: "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="
+    }' package-lock.json > package-lock.json.new
+    mv package-lock.json.new package-lock.json
+    sed -i 's/\.allowExcessArguments()/\.allowExcessArguments?.()/g' cli/src/cli.ts
+  '';
+
+  npmDepsHash = "sha256-YV7+QdQwrQslj4Tw6lGEiLiYUe4NdfUotF2UxJGZe4I=";
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Visual testing tool for MCP servers";
+    homepage = "https://github.com/modelcontextprotocol/inspector";
+    license = licenses.mit;
+    maintainers = ["andoriyu@gmail.com"];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Summary
- package `mcp-inspector` from modelcontextprotocol/inspector
- add missing NPM metadata so the build works offline
- skip `allowExcessArguments` when unsupported so `--help` works

## Testing
- `nix build .#mcp-inspector`
- `NIX_PROGRESS_STYLE=quiet nix flake show --no-write-lock-file`


------
https://chatgpt.com/codex/tasks/task_e_684a3f21a1648327be64e2b198dce40b