### PR TITLE
update(dart-sass): Update dart-sass to 1.89.2

### DIFF
--- a/packages.nix
+++ b/packages.nix
@@ -8,7 +8,7 @@
   neo4j-mcp-packages = pkgs.callPackage ./packages/neo4j-mcp {};
 in
   rec {
-    dart-sass = dart-sass-1_89_1;
+    dart-sass = dart-sass-1_89_2;
     encodec = pkgs.callPackage ./packages/encodec {
       inherit (pkgs.python311Packages) buildPythonPackage;
     };
@@ -16,8 +16,8 @@ in
       inherit encodec; # makes the local copy visible
       inherit (pkgs.python311Packages) buildPythonPackage;
     };
-    dart-sass-1_89_1 =
-      pkgs.callPackage ./packages/dart-sass-snapshot {version = "1.89.1";};
+    dart-sass-1_89_2 =
+      pkgs.callPackage ./packages/dart-sass-snapshot {version = "1.89.2";};
     dart-sass-1_60_0 =
       pkgs.callPackage ./packages/dart-sass-snapshot {version = "1.60.0";};
     mcp-language-server = pkgs.callPackage ./packages/mcp-language-server {};

--- a/packages/dart-sass-snapshot/versions.json
+++ b/packages/dart-sass-snapshot/versions.json
@@ -1,5 +1,29 @@
 [
   {
+    "version": "1.89.2",
+    "platform": "aarch64-darwin",
+    "url": "https://github.com/sass/dart-sass/releases/download/1.89.2/dart-sass-1.89.2-macos-arm64.tar.gz",
+    "sha256": "sha256-8sMUytAE0IjW7/ovWSmu3te/6HDUi+qx58W2/etNfn0="
+  },
+  {
+    "version": "1.89.2",
+    "platform": "aarch64-linux",
+    "url": "https://github.com/sass/dart-sass/releases/download/1.89.2/dart-sass-1.89.2-linux-arm64.tar.gz",
+    "sha256": "sha256-yvlg/xYNKv1SnM2rBoF8l4b4yy+MNpxjiO1e4nizoYU="
+  },
+  {
+    "version": "1.89.2",
+    "platform": "x86_64-darwin",
+    "url": "https://github.com/sass/dart-sass/releases/download/1.89.2/dart-sass-1.89.2-macos-x64.tar.gz",
+    "sha256": "sha256-TQvgue8ANDAa9Cy7zRR65xclP+FMMaZjkODbdfriUyU="
+  },
+  {
+    "version": "1.89.2",
+    "platform": "x86_64-linux",
+    "url": "https://github.com/sass/dart-sass/releases/download/1.89.2/dart-sass-1.89.2-linux-x64.tar.gz",
+    "sha256": "sha256-WXGI6ienJrlKO2aeYXxmbdC4Zlxixwv6tk2s+GLdSw0="
+  },
+  {
     "version": "1.89.1",
     "platform": "aarch64-darwin",
     "url": "https://github.com/sass/dart-sass/releases/download/1.89.1/dart-sass-1.89.1-macos-arm64.tar.gz",

--- a/packages/dart-sass/versions.json
+++ b/packages/dart-sass/versions.json
@@ -1,5 +1,29 @@
 [
   {
+    "version": "1.89.2",
+    "platform": "aarch64-darwin",
+    "url": "https://github.com/sass/dart-sass/releases/download/1.89.2/dart-sass-1.89.2-macos-arm64.tar.gz",
+    "sha256": "sha256-8sMUytAE0IjW7/ovWSmu3te/6HDUi+qx58W2/etNfn0="
+  },
+  {
+    "version": "1.89.2",
+    "platform": "aarch64-linux",
+    "url": "https://github.com/sass/dart-sass/releases/download/1.89.2/dart-sass-1.89.2-linux-arm64.tar.gz",
+    "sha256": "sha256-yvlg/xYNKv1SnM2rBoF8l4b4yy+MNpxjiO1e4nizoYU="
+  },
+  {
+    "version": "1.89.2",
+    "platform": "x86_64-darwin",
+    "url": "https://github.com/sass/dart-sass/releases/download/1.89.2/dart-sass-1.89.2-macos-x64.tar.gz",
+    "sha256": "sha256-TQvgue8ANDAa9Cy7zRR65xclP+FMMaZjkODbdfriUyU="
+  },
+  {
+    "version": "1.89.2",
+    "platform": "x86_64-linux",
+    "url": "https://github.com/sass/dart-sass/releases/download/1.89.2/dart-sass-1.89.2-linux-x64.tar.gz",
+    "sha256": "sha256-WXGI6ienJrlKO2aeYXxmbdC4Zlxixwv6tk2s+GLdSw0="
+  },
+  {
     "version": "1.89.1",
     "platform": "aarch64-darwin",
     "url": "https://github.com/sass/dart-sass/releases/download/1.89.1/dart-sass-1.89.1-macos-arm64.tar.gz",


### PR DESCRIPTION
## Summary
- bump dart-sass snapshot to 1.89.2
- regenerate version metadata for dart-sass packages
- point `dart-sass` to the new version

## Testing
- `NIX_PROGRESS_STYLE=quiet nix flake show`
- `nix build .#dart-sass`

------
https://chatgpt.com/codex/tasks/task_e_684b1368ec5c8327b7c4fa3ae5c18a36