### PR TITLE
fix(mcp-inspector ): Add nodejs to mcp-inspector PATH

### DIFF
--- a/packages/mcp-inspector/default.nix
+++ b/packages/mcp-inspector/default.nix
@@ -26,6 +26,14 @@ buildNpmPackage rec {
     sed -i 's/\.allowExcessArguments()/\.allowExcessArguments?.()/g' cli/src/cli.ts
   '';
 
+  makeWrapperArgs = [
+    "--prefix PATH : ${
+      lib.makeBinPath [
+        nodejs
+      ]
+    }"
+  ];
+
   npmDepsHash = "sha256-YV7+QdQwrQslj4Tw6lGEiLiYUe4NdfUotF2UxJGZe4I=";
 
   doCheck = false;


### PR DESCRIPTION
In `cli.ts` the code that starts the inspector spawns a child node processes with `spawnPromise("node", ...`. This only works if nodejs is already in the users path, and isn't guaranteed to use the same version as the package was build with.

Adding nodejs to the wrapper args addresses this and allows the inspector to start correctly.