### PR TITLE
ci: Handle empty packages in CI build job

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -80,6 +80,7 @@ jobs:
   
   build:
     needs: get-packages
+    if: needs.get-packages.outputs.packages != '[]'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- skip `build` job when no packages are detected

## Testing
- `NIX_PROGRESS_STYLE=quiet nix flake show`
- `nix flake check` *(fails: interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684b8bec76bc8327a1b6d1fa4f27918b