### PR TITLE
Remove nix flake warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,19 @@ Current flake looks like this:
 │   └───x86_64-linux
 │       ├───bark: app
 │       └───wait-for-pr-checks: app
-├───devShell: development environment
 ├───devShells
 │   ├───aarch64-darwin
+│   │   ├───default: development environment
 │   │   ├───node-latest: development environment
 │   │   ├───node-lts: development environment
 │   │   └───rust: development environment
 │   ├───aarch64-linux
+│   │   ├───default: development environment
 │   │   ├───node-latest: development environment
 │   │   ├───node-lts: development environment
 │   │   └───rust: development environment
 │   └───x86_64-linux
+│       ├───default: development environment
 │       ├───node-latest: development environment
 │       ├───node-lts: development environment
 │       └───rust: development environment
@@ -93,7 +95,8 @@ NOTE: Not every package is cached.
 
 ## Default devShell
 
-A development environment with pre-commit hooks configured for:
+The `devShells.<system>.default` environment comes with pre-commit hooks
+configured for:
 - alejandra (Nix formatter)
 - shellcheck (shell script linter)
 - statix (Nix static analysis)

--- a/flake.nix
+++ b/flake.nix
@@ -106,7 +106,7 @@
 
         # ------------------------ pre-commit checks -----------------------
         checks.pre-commit-check = pre-commit-hooks.lib.${system}.run {
-          src = ./.;
+          src = self;
           hooks = {
             alejandra.enable = true;
             shellcheck.enable = true;
@@ -118,11 +118,10 @@
         formatter = pkgs.alejandra;
 
         # ------------------------- dev shells ----------------------------
-        devShell = pkgs.mkShell {
-          inherit (self.checks.${system}.pre-commit-check) shellHook;
-        };
-
         devShells = {
+          default = pkgs.mkShell {
+            inherit (self.checks.${system}.pre-commit-check) shellHook;
+          };
           node-latest = pkgs.mkShell {
             packages = with pkgs; [
               nodejs
@@ -166,8 +165,16 @@
 
         # --------------------------- apps -------------------------------
         apps = {
-          bark = flake-utils.lib.mkApp {drv = barkCli;};
-          wait-for-pr-checks = flake-utils.lib.mkApp {drv = packages.wait-for-pr-checks;};
+          bark =
+            flake-utils.lib.mkApp {drv = barkCli;}
+            // {
+              meta = packages.bark.meta;
+            };
+          wait-for-pr-checks =
+            flake-utils.lib.mkApp {drv = packages.wait-for-pr-checks;}
+            // {
+              meta = packages.wait-for-pr-checks.meta;
+            };
         };
       }
     ));


### PR DESCRIPTION
## Summary
- fix flake pre-commit src path
- provide devShells.default rather than deprecated devShell
- add meta info to CLI apps
- document new devShell layout

## Testing
- `nix fmt .`
- `NIX_PROGRESS_STYLE=quiet nix flake check` *(fails: interrupted by the user)*

------
https://chatgpt.com/codex/tasks/task_e_68547679d2f4832794b8dea0be383e4a