### PR TITLE
Add grit CLI package

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The flake exposes a few specialized shells:
 - `dart-sass-1_89_2` - Dart Sass 1.89.2
 - [`encodec`](https://github.com/facebookresearch/encodec) - Neural audio codec from Meta
 - [`github-mcp-server`](https://github.com/github/github-mcp-server) - MCP server for GitHub API integration
+- [`grit`](https://github.com/honeycombio/gritql) - GritQL CLI for code search and refactoring
 - [`mcp-inspector`](https://github.com/modelcontextprotocol/inspector) - Inspector tool for MCP servers
 - [`mcp-language-server`](https://github.com/isaacphi/mcp-language-server) - Language server for MCP protocol
 - [`mcp-neo4j-cloud-aura-api`](https://github.com/neo4j-contrib/mcp-neo4j) - Neo4j MCP server for Aura cloud service management

--- a/packages.nix
+++ b/packages.nix
@@ -35,6 +35,7 @@ in
     wait-for-pr-checks = pkgs.callPackage ./packages/wait-for-pr-checks {};
 
     github-mcp-server = pkgs.callPackage ./packages/github-mcp-server {};
+    grit = pkgs.callPackage ./packages/grit {};
     gemini-cli = pkgs.callPackage ./packages/gemini-cli {};
     mcp-inspector = pkgs.callPackage ./packages/mcp-inspector {};
     mcp-prompts = pkgs.callPackage ./packages/mcp-prompts {};

--- a/packages/grit/default.nix
+++ b/packages/grit/default.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-UGZ5J/7DeA847p700EMywxVMnmv1In00mgmd3rlKFuU=";
+  cargoHash = "sha256-WNUqNATPtWfCQX5jpRD0wgLd/fOlJflumNohIwXcFK8=";
 
   nativeBuildInputs = [pkg-config];
   buildInputs = [openssl];

--- a/packages/grit/default.nix
+++ b/packages/grit/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "grit";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "honeycombio";
+    repo = "gritql";
+    rev = "1477fecd90e967b7e298dc3e75ff6ed103e152a8";
+    sha256 = "sha256-ZtBdM7qA4QOAxJ6eREmremjnFJm+CYgZCMnwczmPmyc=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-UGZ5J/7DeA847p700EMywxVMnmv1In00mgmd3rlKFuU=";
+
+  nativeBuildInputs = [pkg-config];
+  buildInputs = [openssl];
+
+  meta = with lib; {
+    description = "GritQL CLI for querying and rewriting source code";
+    homepage = "https://github.com/honeycombio/gritql";
+    license = licenses.mit;
+    mainProgram = "grit";
+    maintainers = [];
+  };
+}

--- a/packages/grit/default.nix
+++ b/packages/grit/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
     owner = "honeycombio";
     repo = "gritql";
     rev = "1477fecd90e967b7e298dc3e75ff6ed103e152a8";
-    sha256 = "sha256-ZtBdM7qA4QOAxJ6eREmremjnFJm+CYgZCMnwczmPmyc=";
+    sha256 = "sha256-ZruQYnqk4epxp0c/9P5dNrj2d5uJy++uwuIEmJ5l3Ls=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Summary
- package GritQL CLI from honeycombio/gritql
- expose it in packages set
- document new package in README

## Testing
- `nix build .#checks.x86_64-linux.pre-commit-check` *(fails: built but truncated)*
- `nix build .#grit` *(failed/interrupted due to long build)*

------
https://chatgpt.com/codex/tasks/task_e_6862d3ea67488327b3deb5918608e0c2