### PR TITLE
Add BSD-2-Clause license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2021-2025 Andrey Cherkashin
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -154,3 +154,7 @@ Include the module and list desired plugin packages via `services.neo4j.plugins`
   };
 }
 ```
+
+## License
+
+This project is licensed under the [BSD 2-Clause](LICENSE) license.


### PR DESCRIPTION
## Summary
- add BSD-2-Clause LICENSE file
- document license in README

## Testing
- `nix flake show`
- `nix develop -c pre-commit run --files LICENSE README.md`
- `nix flake check` *(fails: interrupted by the user)*

------
https://chatgpt.com/codex/tasks/task_e_68640e0bdc408327b5bf827613f22a92