### PR TITLE
Add readable-name-generator package

### DIFF
--- a/packages.nix
+++ b/packages.nix
@@ -39,6 +39,7 @@ in
     gemini-cli = pkgs.callPackage ./packages/gemini-cli {};
     mcp-inspector = pkgs.callPackage ./packages/mcp-inspector {};
     mcp-prompts = pkgs.callPackage ./packages/mcp-prompts {};
+    readable-name-generator = pkgs.callPackage ./packages/readable-name-generator {};
     neo4j-apoc = neo4j-apoc-pkg;
     catppuccin-gitea = pkgs.callPackage ./packages/catppuccin-gitea {};
   }

--- a/packages/readable-name-generator/default.nix
+++ b/packages/readable-name-generator/default.nix
@@ -1,0 +1,23 @@
+{ lib, rustPlatform, fetchFromGitea, ... }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "readable-name-generator";
+  version = "4.3.3";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "PurpleBooth";
+    repo = "readable-name-generator";
+    rev = "v4.3.3";
+    sha256 = "sha256-xE0j8qjMDRKajR1EJfGLw3eKgvbQEHTUwGzTqVr4CL0=";
+  };
+
+  cargoHash = "sha256-FJNXC6Ab8t6Lq/6fUxHUGpsjkircP4A4L6fZN3Ig2WI=";
+
+  meta = with lib; {
+    description = "Generate a readable name for throwaway infrastructure";
+    homepage = "https://codeberg.org/PurpleBooth/readable-name-generator";
+    license = licenses.cc0;
+    maintainers = [];
+  };
+}


### PR DESCRIPTION
## Summary
- package readable-name-generator

## Testing
- `nix build .#readable-name-generator`
- `nix flake check` *(fails: process interrupted due to resource usage)*

------
https://chatgpt.com/codex/tasks/task_e_689d3305c4508327a269ec705995d510