### PR TITLE
Add searxng MCP package

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Current flake looks like this:
     │   ├───mcp-neo4j-memory
     │   ├───mcp-prompts
     │   ├───neo4j-apoc
+    │   ├───searxng-mcp
     │   └───wait-for-pr-checks
     ├───aarch64-linux
     │   ├───City
@@ -62,6 +63,7 @@ Current flake looks like this:
     │   ├───mcp-neo4j-memory
     │   ├───mcp-prompts
     │   ├───neo4j-apoc
+    │   ├───searxng-mcp
     │   ├───st-onedark
     │   └───wait-for-pr-checks
     └───x86_64-linux
@@ -79,6 +81,7 @@ Current flake looks like this:
         ├───mcp-neo4j-memory
         ├───mcp-prompts
         ├───neo4j-apoc
+        ├───searxng-mcp
         ├───st-onedark
         └───wait-for-pr-checks
 ```
@@ -125,6 +128,7 @@ The flake exposes a few specialized shells:
 - [`mcp-neo4j-cypher`](https://github.com/neo4j-contrib/mcp-neo4j) - Neo4j MCP server for natural language to Cypher queries
 - [`mcp-neo4j-memory`](https://github.com/neo4j-contrib/mcp-neo4j) - Neo4j MCP server for knowledge graph memory
 - [`mcp-prompts`](https://github.com/sparesparrow/mcp-prompts) - Collection of MCP prompts
+- [`searxng-mcp`](https://github.com/tisDDM/searxng-mcp) - MCP server for performing web searches using SearXNG
 - [`neo4j-apoc`](https://github.com/neo4j/apoc) - Neo4j APOC plugin
 - [`st-onedark`](https://st.suckless.org/) - St terminal with OneDark theme
 - `wait-for-pr-checks` - Monitor GitHub PR checks with exponential backoff

--- a/packages.nix
+++ b/packages.nix
@@ -39,6 +39,7 @@ in
     gemini-cli = pkgs.callPackage ./packages/gemini-cli {};
     mcp-inspector = pkgs.callPackage ./packages/mcp-inspector {};
     mcp-prompts = pkgs.callPackage ./packages/mcp-prompts {};
+    searxng-mcp = pkgs.callPackage ./packages/searxng-mcp {};
     neo4j-apoc = neo4j-apoc-pkg;
     catppuccin-gitea = pkgs.callPackage ./packages/catppuccin-gitea {};
   }

--- a/packages/searxng-mcp/default.nix
+++ b/packages/searxng-mcp/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs,
+  ...
+}:
+buildNpmPackage rec {
+  pname = "searxng-mcp";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "tisDDM";
+    repo = "searxng-mcp";
+    rev = "e4b0fe297e3aac11554deae84d475d6eb6e51ac8";
+    sha256 = "sha256-w5STFYeOIHMTyfz2ViAkV8GD/CzvWYUtWIz3l7Dpk3A=";
+  };
+
+  npmDepsHash = "sha256-2GD4wiNA1MNQmB4agJchXeSWTyYUptXogl3y6z0SKn4=";
+
+  makeWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [nodejs]}"
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    mainProgram = "searxngmcp";
+    description = "MCP server for performing web searches using SearXNG";
+    homepage = "https://github.com/tisDDM/searxng-mcp";
+    license = licenses.mit;
+    maintainers = [];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Summary
- package SearXNG MCP server as a Nix flake package
- expose searxng-mcp in packages set and documentation

## Testing
- `nix build .#searxng-mcp`
- `nix build .#checks.x86_64-linux.pre-commit-check` *(fails: SC2181 in wait-for-pr-checks tests; statix warnings in modules/home-manager/pushover.nix)*


------
https://chatgpt.com/codex/tasks/task_e_6893e93de34c83278f20c403cb4525af